### PR TITLE
Fixed prompt text no longer being copied to the prompts struct

### DIFF
--- a/src/userauth.c
+++ b/src/userauth.c
@@ -1540,6 +1540,8 @@ userauth_keyboard_interactive(LIBSSH2_SESSION * session,
                                        "keyboard-interactive prompt message");
                         goto cleanup;
                     }
+                    memcpy(session->userauth_kybd_prompts[i].text, s,
+                           session->userauth_kybd_prompts[i].length);
                     s += session->userauth_kybd_prompts[i].length;
 
                     /* boolean   echo[1] */


### PR DESCRIPTION
Regression in 1.5 from 1.4.4.